### PR TITLE
10章のlangchainのバージョンに起因するエラーの対応を記載

### DIFF
--- a/chapter10/notebook.ipynb
+++ b/chapter10/notebook.ipynb
@@ -22,8 +22,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%cd agent-book\n",
-    "%cd chapter10"
+    "!pip install langchain-core==0.3.0 langchain-openai==0.2.0 langgraph==0.2.22 python-dotenv==1.0.1 pydantic==2.10.6"
    ]
   },
   {
@@ -32,7 +31,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install langchain-core==0.3.0 langchain-openai==0.2.0 langgraph==0.2.22 python-dotenv==1.0.1 pydantic==2.10.6"
+    "# 以下のエラーの対策として、langchainの動作確認済みバージョンをインストール\n",
+    "# AttributeError: module 'langchain' has no attribute 'verbose'\n",
+    "\n",
+    "!pip install --no-deps langchain==0.3.23"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cd agent-book\n",
+    "%cd chapter10"
    ]
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * LangChainの既知エラー（AttributeError: module 'langchain' has no attribute 'verbose'）を解決しました

* **その他**
  * ノートブックのセットアップ手順を改善し、LangChain 0.3.23を使用した新しいインストール方法を導入しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->